### PR TITLE
Re-export `precis_core`

### DIFF
--- a/precis-profiles/Cargo.toml
+++ b/precis-profiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "precis-profiles"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Santiago Carot-Nemesio <sancane@gmail.com"]
 description = """
 Implementation of the PRECIS Framework: Preparation, Enforcement,

--- a/precis-profiles/src/lib.rs
+++ b/precis-profiles/src/lib.rs
@@ -36,3 +36,4 @@ pub use crate::nicknames::Nickname;
 pub use crate::passwords::OpaqueString;
 pub use crate::usernames::UsernameCaseMapped;
 pub use crate::usernames::UsernameCasePreserved;
+pub use precis_core;


### PR DESCRIPTION
Re-export `precis_core` and increment the patch version in `Cargo.toml`.

Fixes #48.